### PR TITLE
Use fork of word-wrap

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
   "proxy": "http://localhost:5000",
   "resolutions": {
     "react-charts/d3-scale/d3-interpolate/d3-color": "^3.1.0",
-    "react-scripts/**/nth-check": "2.0.1"
+    "react-scripts/**/nth-check": "2.0.1",
+    "word-wrap": "npm:@aashutoshrathi/word-wrap@1.2.6"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10530,10 +10530,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+word-wrap@^1.2.3, "word-wrap@npm:@aashutoshrathi/word-wrap@1.2.6", word-wrap@~1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
+  integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 workbox-background-sync@6.5.4:
   version "6.5.4"


### PR DESCRIPTION
word-wrap has a vulnerability but appears to be unmaintained. There is a fork that fixes the vulnerability.

https://github.com/jonschlinkert/word-wrap/compare/master...aashutoshrathi:word-wrap:b412747338cf61569ce83df8af5f1bda1e15ab33

Fixes https://github.com/ferocia/matchbot/security/dependabot/85